### PR TITLE
apply NRS standard table names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,11 @@
             <artifactId>swagger-core</artifactId>
             <version>${swagger-core-version}</version>
         </dependency>  
+        <dependency>
+          <groupId>com.samskivert</groupId>
+          <artifactId>jmustache</artifactId>
+          <version>1.13</version>
+        </dependency>
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-codegen</artifactId>

--- a/src/main/java/io/swagger/codegen/languages/DjangoGenerator.java
+++ b/src/main/java/io/swagger/codegen/languages/DjangoGenerator.java
@@ -70,12 +70,27 @@ public class DjangoGenerator extends DefaultCodegen implements CodegenConfig {
 
         
     }
+
+    private String snakify(String input) {
+        StringBuilder builder = new StringBuilder("");
+        int length = input.length();
+        for (int i = 0; i < length; i++) {
+            char c = input.charAt(i);
+            if (Character.isUpperCase(c) && i != 0) {
+                 builder.append("_");
+            }
+            builder.append(Character.toUpperCase(c));
+        }
+
+        return builder.toString();
+    }
+
     @Override
     public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {        
         
         String modelDatatype = "";
         String nullString = "";
-        
+
         if (property != null)
         {
             if (!Boolean.TRUE.equals(property.required))
@@ -216,6 +231,9 @@ public class DjangoGenerator extends DefaultCodegen implements CodegenConfig {
             // add a lower case plural form of the model suitable for making a service out of.
             String pluralClassname = English.plural(cm.classname);
             cm.vendorExtensions.put ("pluralClassname", pluralClassname.toLowerCase());
+
+            cm.vendorExtensions.put ("tableName", snakify(cm.classname));
+
             String modelImports = "";
             List<String> modelImportList = new java.util.Vector<String>();
             

--- a/src/main/resources/django/models.mustache
+++ b/src/main/resources/django/models.mustache
@@ -8,11 +8,14 @@ from django.utils import timezone
 {{#model}}
 {{{vendorExtensions.modelImports}}}
 
-class {{classname}}(models.Model):	    
-{{#vars}}    {{name}} = {{{vendorExtensions.modelDatatype}}}   
+class {{classname}}(models.Model):
+    class Meta:
+        db_table = '{{vendorExtensions.tableName}}'
+
+{{#vars}}    {{name}} = {{{vendorExtensions.modelDatatype}}}
 {{/vars}}
 {{#vendorExtensions.x-codegen-viewmodel}}
     class Meta:
-      abstract = True
+        abstract = True
 {{/vendorExtensions.x-codegen-viewmodel}}{{/model}}
 {{/models}}


### PR DESCRIPTION
This commit adds the `db_table` variable to all models and inputs the
NRS compliant model name into that variable. This will have the effect
of changing the table name of the model to an a string that is all
uppercase and separated by underscores.